### PR TITLE
Update CRD definition schema API group to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,9 @@ kubectl get FunctionIngress -n openfaas
 
 Remember to configure DNS for `nodeinfo.myfaas.club` or edit `/etc/hosts` and point to your `IngressController`'s IP or `LoadBalancer`.
 
+## Kubernetes versions
+Ingress Operator currently requires Kubernetes version 1.16+
+
 ## Contributing
 
 This project follows the [OpenFaaS contributing guide](./CONTRIBUTING.md)

--- a/artifacts/crds/openfaas.com_functioningresses.yaml
+++ b/artifacts/crds/openfaas.com_functioningresses.yaml
@@ -1,10 +1,8 @@
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: functioningresses.openfaas.com
 spec:
@@ -15,70 +13,69 @@ spec:
     plural: functioningresses
     singular: functioningress
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: FunctionIngress describes an OpenFaaS function
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: FunctionIngressSpec is the spec for a FunctionIngress resource.
-            It must be created in the same namespace as the gateway, i.e. openfaas.
-          properties:
-            bypassGateway:
-              description: BypassGateway, when true creates an Ingress record directly
-                for the Function name without using the gateway in the hot path
-              type: boolean
-            domain:
-              description: Domain such as "api.example.com"
-              type: string
-            function:
-              description: Function such as "nodeinfo"
-              type: string
-            ingressType:
-              description: IngressType such as "nginx"
-              type: string
-            path:
-              description: Path such as "/v1/profiles/view/(.*)", or leave empty for
-                default
-              type: string
-            tls:
-              description: Enable TLS via cert-manager
-              properties:
-                enabled:
-                  type: boolean
-                issuerRef:
-                  description: ObjectReference is a reference to an object with a
-                    given name and kind.
-                  properties:
-                    kind:
-                      type: string
-                    name:
-                      type: string
-                  required:
-                  - name
-                  type: object
-              type: object
-          required:
-          - domain
-          - function
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1alpha2
   versions:
   - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: FunctionIngress describes an OpenFaaS function
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FunctionIngressSpec is the spec for a FunctionIngress resource.
+              It must be created in the same namespace as the gateway, i.e. openfaas.
+            type: object
+            required:
+            - domain
+            - function
+            properties:
+              bypassGateway:
+                description: BypassGateway, when true creates an Ingress record directly
+                  for the Function name without using the gateway in the hot path
+                type: boolean
+              domain:
+                description: Domain such as "api.example.com"
+                type: string
+              function:
+                description: Function such as "nodeinfo"
+                type: string
+              ingressType:
+                description: IngressType such as "nginx"
+                type: string
+              path:
+                description: Path such as "/v1/profiles/view/(.*)", or leave empty
+                  for default
+                type: string
+              tls:
+                description: Enable TLS via cert-manager
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                  issuerRef:
+                    description: ObjectReference is a reference to an object with
+                      a given name and kind.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
     served: true
     storage: true
 status:

--- a/hack/update-crds.sh
+++ b/hack/update-crds.sh
@@ -3,15 +3,15 @@
 export controllergen="$GOPATH/bin/controller-gen"
 export PKG=sigs.k8s.io/controller-tools/cmd/controller-gen
 
-if [ ! -e "$gen" ]
+if [ ! -e "$controllergen" ]
 then
 echo "Getting $PKG"
     GO111MODULE=off go get $PKG
 fi
 
-echo $controllergen
+echo "using $controllergen"
 
-echo "$controllergen" \
+"$controllergen" \
   crd \
   schemapatch:manifests=./artifacts/crds \
   paths=./pkg/apis/... \


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Update the CRD definition schema to use the v1 API. The beta API is
  being deprecated and will be removed in v1.19 (which is coming soon)
- Add k8s version requirement to the README

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with a local Kind cluster

```sh
$ kind create cluster
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.0", GitCommit:"70132b0f130acc0bed193d9ba59dd186f0e634cf", GitTreeState:"clean", BuildDate:"2019-12-13T11:52:32Z", GoVersion:"go1.13.4", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.2", GitCommit:"52c56ce7a8272c798dbc29846288d7cd9fbae032", GitTreeState:"clean", BuildDate:"2020-04-30T20:19:45Z", GoVersion:"go1.13.9", Compiler:"gc", Platform:"linux/amd64"}
$ kubectl apply -f artifacts/crds/
customresourcedefinition.apiextensions.k8s.io/functioningresses.openfaas.com created
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Impact to existing users
<!-- What must existing users do to adopt this change? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
