### PR TITLE
feat: check server capabilities usin the preferred resources endpoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+.vscode
+.tools
+artifacts
+examples
+hack

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,6 @@ jobs:
 
       - name: Set Username/Repo and ImagePrefix as ENV vars
         run: |
-          echo "USER_REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV} && \
           echo "IMAGE_PREFIX=ghcr.io/${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
 
       - name: Build x86_64 container into library
@@ -39,7 +38,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         with:
           registry: ghcr.io
-          username: ${{ env.USER_REPO }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Pull Request test image
@@ -62,7 +61,6 @@ jobs:
 
       - name: Set Username/Repo and ImagePrefix as ENV vars
         run: |
-          echo "USER_REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV} && \
           echo "IMAGE_PREFIX=ghcr.io/${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
 
       - name: Build multi-arch containers for validation only

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,14 +9,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      checks: write
-      issues: read
-      packages: write
-      pull-requests: read
-      repository-projects: read
-      statuses: read
     steps:
       - uses: actions/checkout@master
       - name: Set up QEMU

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Pull Request test image
-        uses: contiamo/retag-push@main
+        uses: contiamo/retag-push@v1.0.0
         if: ${{ github.event_name == 'pull_request' }}
         with:
           source: ${{ env.IMAGE_PREFIX }}:${{ github.sha }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: write
+      issues: read
+      packages: write
+      pull-requests: read
+      repository-projects: read
+      statuses: read
     steps:
       - uses: actions/checkout@master
       - name: Set up QEMU

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,21 +8,18 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        go-version: [1.13.x]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+
+      - name: Set Username/Repo and ImagePrefix as ENV vars
+        run: |
+          echo "USER_REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV} && \
+          echo "IMAGE_PREFIX=ghcr.io/${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
 
       - name: Build x86_64 container into library
         uses: docker/build-push-action@v2
@@ -30,9 +27,43 @@ jobs:
           context: .
           file: ./Dockerfile
           outputs: "type=docker,push=false"
+          build-args: |
+            VERSION=latest-dev
+            GIT_COMMIT=${{ github.sha }}
           platforms: linux/amd64
           tags: |
-            ghcr.io/openfaas/ingress-operator:${{ github.sha }}
+            ${{ env.IMAGE_PREFIX }}:${{ github.sha }}
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v1
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          registry: ghcr.io
+          username: ${{ env.USER_REPO }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Pull Request test image
+        uses: contiamo/retag-push@main
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          source: ${{ env.IMAGE_PREFIX }}:${{ github.sha }}
+          target: |
+            ${{ env.IMAGE_PREFIX }}:pr-${{github.event.number}}
+
+  build-multi-arch:
+    # run in parallel to build because multi-arch is slow
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Set Username/Repo and ImagePrefix as ENV vars
+        run: |
+          echo "USER_REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV} && \
+          echo "IMAGE_PREFIX=ghcr.io/${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
 
       - name: Build multi-arch containers for validation only
         uses: docker/build-push-action@v2
@@ -40,6 +71,9 @@ jobs:
           context: .
           file: ./Dockerfile
           outputs: "type=image,push=false"
+          build-args: |
+            VERSION=latest-dev
+            GIT_COMMIT=${{ github.sha }}
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           tags: |
-            ghcr.io/openfaas/ingress-operator:${{ github.sha }}
+            ${{ env.IMAGE_PREFIX }}:${{ github.sha }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,22 +41,6 @@ jobs:
           tags: |
             ${{ env.IMAGE_PREFIX }}:${{ github.sha }}
 
-      - name: Login to Docker Registry
-        uses: docker/login-action@v1
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish Pull Request test image
-        uses: contiamo/retag-push@v1.0.0
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          source: ${{ env.IMAGE_PREFIX }}:${{ github.sha }}
-          target: |
-            ${{ env.IMAGE_PREFIX }}:pr-${{github.event.number}}
-
   build-multi-arch:
     # run in parallel to build because multi-arch is slow
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,14 +19,13 @@ jobs:
         run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
       - name: Set Username/Repo and ImagePrefix as ENV vars
         run: |
-          echo "USER_REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV} && \
           echo "IMAGE_PREFIX=ghcr.io/${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
 
       - name: Login to Docker Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ env.USER_REPO }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push containers
         uses: docker/build-push-action@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,17 +7,9 @@ on:
 
 jobs:
   publish:
-    strategy:
-      matrix:
-        go-version: [1.13.x]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -25,22 +17,28 @@ jobs:
       - name: Get TAG
         id: get_tag
         run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+      - name: Set Username/Repo and ImagePrefix as ENV vars
+        run: |
+          echo "USER_REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV} && \
+          echo "IMAGE_PREFIX=ghcr.io/${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+
       - name: Login to Docker Registry
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
           registry: ghcr.io
+          username: ${{ env.USER_REPO }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push containers
         uses: docker/build-push-action@v2
         with:
           context: .
           file: ./Dockerfile
           outputs: "type=registry,push=true"
+          build-args: |
+            VERSION=${{ steps.get_tag.outputs.TAG }}
+            GIT_COMMIT=${{ github.sha }}
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           tags: |
-            ghcr.io/openfaas/ingress-operator:${{ github.sha }}
-            ghcr.io/openfaas/ingress-operator:${{ steps.get_tag.outputs.TAG }}
-            ghcr.io/openfaas/ingress-operator:latest
+            ${{ env.IMAGE_PREFIX }}:${{ github.sha }}
+            ${{ env.IMAGE_PREFIX }}:${{ steps.get_tag.outputs.TAG }}
+            ${{ env.IMAGE_PREFIX }}:latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,14 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: write
+      issues: read
+      packages: write
+      pull-requests: read
+      repository-projects: read
+      statuses: read
     steps:
       - uses: actions/checkout@master
       - name: Set up QEMU

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ config
 password.txt
 faas-netes/**
 test.yaml
+cluster.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ ingress-operator
 config
 password.txt
 faas-netes/**
+test.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=${BUILDPLATFORM:-linux/amd64} teamserverless/license-check:0.3.9 as license-check
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.15 as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.16 as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,14 @@ ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
+ARG GIT_COMMIT
+ARG VERSION
+
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
 ENV GOFLAGS=-mod=vendor
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${TARGETARCH}
 
 COPY --from=license-check /license-check /usr/bin/
 
@@ -22,9 +27,7 @@ ARG OPTS
 
 RUN gofmt -l -d $(find . -type f -name '*.go' -not -path "./vendor/*")
 RUN go test -mod=vendor -v ./...
-RUN VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags | sed 's/tags\///') && \
-  GIT_COMMIT=$(git rev-list -1 HEAD) && \
-  env ${OPTS} GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=${CGO_ENABLED} GOOS=linux go build -mod=vendor -ldflags "-s -w \
+RUN go build -mod=vendor -ldflags "-s -w \
   -X github.com/openfaas-incubator/ingress-operator/pkg/version.Release=${VERSION} \
   -X github.com/openfaas-incubator/ingress-operator/pkg/version.SHA=${GIT_COMMIT}" \
   -a -installsuffix cgo -o ingress-operator . && \

--- a/main.go
+++ b/main.go
@@ -94,15 +94,17 @@ func main() {
 	klog.Infof("cluster supports ingress in: %s", capabilities)
 
 	var ctrl controller
-	if capabilities.Has("extensions/v1beta1") {
-		ctrl = controllerv1beta1.NewController(
+	// prefer v1, if it is available, this removes any deprecation warnings
+	if capabilities.Has("networking.k8s.io/v1") {
+		ctrl = controllerv1.NewController(
 			kubeClient,
 			faasClient,
 			kubeInformerFactory,
 			faasInformerFactory,
 		)
 	} else {
-		ctrl = controllerv1.NewController(
+		// use v1beta1 by default
+		ctrl = controllerv1beta1.NewController(
 			kubeClient,
 			faasClient,
 			kubeInformerFactory,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Using the preferred resources endpoit allows us to test for specific API
groups that contain a specific resource kind, in this case we can test
for which API groups that exist and support Ingress.

ci: remove git from the docker build context

Pass the versio data via build arguments instead of passing the entire
git database. This cuts the build context in half.

ci: update multi-arch build flow

Use the build process from faas-netes to simplify the multi-arch build
process.

ci: allow pushing to fork ghcr repos

ci: push preview images for PRs

ci: build multi-arch in paraller for speed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Closes #51
Closes #44 
Improve #50   

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Create the files `cluster.yaml` and `test.yaml`

```yaml
# cluster.yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
  kubeadmConfigPatches:
  - |
    kind: InitConfiguration
    nodeRegistration:
      kubeletExtraArgs:
        node-labels: "ingress-ready=true"
  extraPortMappings:
  - containerPort: 80
    hostPort: 80
    protocol: TCP
  - containerPort: 443
    hostPort: 443
    protocol: TCP
  - containerPort: 31112 # this is the NodePort created by the helm chart
    hostPort: 8080 # this is your port on localhost
    protocol: TCP
```


```yaml
# test.yaml
apiVersion: openfaas.com/v1alpha2
kind: FunctionIngress
metadata:
  name: nodeinfo
  namespace: openfaas
spec:
  domain: "nodeinfo.myfaas.club"
  function: "nodeinfo"
  ingressType: "nginx"
  path: "/v1/profiles/(.*)"
```

Then, deploy a 1.19 cluster using
```sh
kind create cluster --image kindest/node:v1.19.11 --config=cluster.yaml
```

and install the test operator


```sh
$ kind create cluster --config=cluster.yaml
$ arkade install openfaas \
	--basic-auth=false \
	--clusterrole \
	--ingress-operator \
	--set ingressOperator.image=ghcr.io/lucasroesler/ingress-operator:pr-1


$ faas-cli store deploy nodeinfo
$ kubectl apply -f test.yaml
$ kubectl get ing
Warning: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
NAME       CLASS    HOSTS                  ADDRESS   PORTS   AGE
nodeinfo   <none>   nodeinfo.myfaas.club             80      5s
```

```sh
$ kubectl -n openfaas logs deploy/ingress-operator 
I0829 09:49:55.758358       1 main.go:54] Starting FunctionIngress controller version: latest-dev commit: 56f035ce56c466f8b3b73cafd55dd735af933e58
W0829 09:49:55.758563       1 client_config.go:615] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0829 09:49:55.770796       1 main.go:94] cluster supports ingress in: extensions/v1beta1, networking.k8s.io/v1
I0829 09:49:55.771156       1 controller.go:70] Setting up event handlers
I0829 09:49:55.771239       1 core.go:72] Waiting for informer caches to sync
I0829 09:49:55.872037       1 core.go:77] Starting workers
I0829 09:49:55.872053       1 core.go:83] Started workers
I0829 09:49:55.872087       1 controller.go:103] FunctionIngress name: nodeinfo
I0829 09:49:55.872098       1 controller.go:112] fni.Spec.UseTLS() false
I0829 09:49:55.872102       1 controller.go:113] createIngress false
```

Specifically take note of this log line:

```sh
I0829 09:49:55.770796       1 main.go:94] cluster supports ingress in: extensions/v1beta1, networking.k8s.io/v1
```


Deploy a 1.22 cluster using
```sh
kind create cluster --image kindest/node:v1.22.1 --config=cluster.yaml
```

Re-run the tests

```sh
$ kind create cluster --config=cluster.yaml
$ arkade install openfaas \
	--basic-auth=false \
	--clusterrole \
	--ingress-operator \
	--set ingressOperator.image=ghcr.io/lucasroesler/ingress-operator:pr-1


$ faas-cli store deploy nodeinfo
$ kubectl apply -f test.yaml
$ kubectl -n openfaas get ing
NAME       CLASS    HOSTS                  ADDRESS   PORTS   AGE
nodeinfo   <none>   nodeinfo.myfaas.club             80      5s
```

The logs now show only one supported API 

```sh
$ kubectl -n openfaas logs deploy/ingress-operator
I0829 10:07:16.357689       1 main.go:54] Starting FunctionIngress controller version: latest-dev commit: 56f035ce56c466f8b3b73cafd55dd735af933e58
W0829 10:07:16.357836       1 client_config.go:615] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0829 10:07:16.366955       1 main.go:94] cluster supports ingress in: networking.k8s.io/v1
I0829 10:07:16.367052       1 controller.go:70] Setting up event handlers
I0829 10:07:16.367089       1 core.go:72] Waiting for informer caches to sync
I0829 10:07:16.467864       1 core.go:77] Starting workers
I0829 10:07:16.467917       1 core.go:83] Started workers
I0829 10:07:43.764285       1 controller.go:103] FunctionIngress name: nodeinfo
I0829 10:07:43.764332       1 controller.go:112] fni.Spec.UseTLS() false
I0829 10:07:43.764338       1 controller.go:113] createIngress true
```

Note: `I0829 10:07:16.366955       1 main.go:94] cluster supports ingress in: networking.k8s.io/v1`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Impact to existing users
<!-- What must existing users do to adopt this change? -->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
